### PR TITLE
Fix npm install error

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -6,7 +6,7 @@ npm-debug.log
 Thumbs.db
 .DS_Store
 /.idea
-/**/*.ts
+!/**/*.ts
 !/**/*.d.ts
 runtime
 typings


### PR DESCRIPTION
ignoring the ts files results in unnecessary warnings. It doesn't really make sense either, if your development cycle includes using the ts files.