### PR TITLE
Issue #104

### DIFF
--- a/src/exif.ts
+++ b/src/exif.ts
@@ -314,7 +314,7 @@ export class Exif {
         http.open("GET", url, true);
         http.responseType = "blob";
         http.onload = function () {
-            if (this.status === 200 || this.status === 0) {
+            if (http.status === 200 || http.status === 0) {
                 callback(http.response);
             }
         };
@@ -348,7 +348,7 @@ export class Exif {
                 } else {
                     let http = new XMLHttpRequest();
                     http.onload = function () {
-                        if (this.status === 200 || this.status === 0) {
+                        if (http.status === 200 || http.status === 0) {
                             handleBinaryFile(http.response);
                         } else {
                             throw "Could not load image";


### PR DESCRIPTION
Changed `this.status` to `http.status`. This works for me because `this` is an `XMLHttpRequestEventTarget` object, which does not contain a `status` property. I believe you meant to reference `http`, which is an `XMLHttpRequest` object that does have a `status` property.