### PR TITLE
explicit stroke and fill settings for drag icon

### DIFF
--- a/src/cropperDrawSettings.ts
+++ b/src/cropperDrawSettings.ts
@@ -1,4 +1,7 @@
 export class CropperDrawSettings {
     public strokeWidth: number = 1;
     public strokeColor: string = "rgba(255,255,255,1)";
+    public dragIconStrokeWidth: number = 1;
+    public dragIconStrokeColor: string = "rgba(0,0,0,1)";
+    public dragIconFillColor: string = "rgba(255,255,255,1)";
 }

--- a/src/model/dragMarker.ts
+++ b/src/model/dragMarker.ts
@@ -65,8 +65,11 @@ export class DragMarker extends Handle {
             ctx.lineTo(p.x + this.position.x, p.y + this.position.y);
         }
         ctx.closePath();
-        ctx.fillStyle = this.cropperSettings.cropperDrawSettings.strokeColor;
+        ctx.fillStyle = this.cropperSettings.cropperDrawSettings.dragIconFillColor;
         ctx.fill();
+        ctx.lineWidth = this.cropperSettings.cropperDrawSettings.dragIconStrokeWidth;
+        ctx.strokeStyle = this.cropperSettings.cropperDrawSettings.dragIconStrokeColor;
+        ctx.stroke();
     }
 
     public recalculatePosition(bounds: Bounds) {


### PR DESCRIPTION
The white drag icon is almost invisible on bright images, so we draw a
stroke around it. Settings are made via CropperDrawSettings.