### PR TITLE
Pr 145 return value

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,6 @@
     "@angular/http": "~2.3.0",
     "@angular/platform-browser": "~2.3.0",
     "@angular/platform-browser-dynamic": "~2.3.0",
-    "@types/es6-shim": "^0.31.32",
     "angular-in-memory-web-api": "~0.1.17",
     "concurrently": "^2.2.0",
     "core-js": "^2.4.1",

--- a/src/imageCropper.ts
+++ b/src/imageCropper.ts
@@ -940,6 +940,7 @@ export class ImageCropper extends ImageCropperModel {
                 return this.currentDragTouches[i];
             }
         }
+        return undefined;
     }
 
     public drawCursors(cropTouch:CropTouch) {
@@ -1012,7 +1013,7 @@ export class ImageCropper extends ImageCropperModel {
             for (let i = 0; i < event.changedTouches.length; i++) {
                 let touch = event.changedTouches[i];
                 let dragTouch = this.getDragTouchForID(touch.identifier);
-                if (dragTouch && dragTouch !== null) {
+                if (dragTouch && dragTouch !== undefined) {
                     if (dragTouch.dragHandle instanceof CornerMarker || dragTouch.dragHandle instanceof DragMarker) {
                         dragTouch.dragHandle.setOver(false);
                     }


### PR DESCRIPTION
Resolves "not all paths return a value" error on compiling with Angular 2.4.10.
When compiling with tsc in dev environment (IDE Typescript 2.2.1) I got a lot of shim-es6 errors for typings. Removing typings for es6 solved this issue.

You may want to check this against your env though, as I am unsure whether this will be fine in every case.