### PR TITLE
first steps towards bypassing setImage with a custom file input

### DIFF
--- a/src/imageCropperComponent.ts
+++ b/src/imageCropperComponent.ts
@@ -28,6 +28,7 @@ export class ImageCropperComponent implements AfterViewInit, OnChanges {
 
     @Input('settings') public settings:CropperSettings;
     @Input('image') public image:any;
+    @Input('inputImage') public inputImage:any;
     @Input() public cropper:ImageCropper;
     @Input() public cropPosition:CropPosition;
     @Output() public cropPositionChange:EventEmitter<CropPosition> = new EventEmitter<CropPosition>();
@@ -81,6 +82,10 @@ export class ImageCropperComponent implements AfterViewInit, OnChanges {
                 this.onCrop.emit(bounds);
             }
             this.updateCropBounds();
+        }
+
+        if (changes.inputImage) {
+          this.setImage(changes.inputImage.currentValue);
         }
     }
 


### PR DESCRIPTION
I don't really expect this to be taken as is, but it did work for me, and almost certainly did not break anything else, so maybe it's good enough for a first cut. This problem actively impeded my progress due to [this issue](https://github.com/cstefanache/angular2-img-cropper/issues/128), and while there are some angular hacks available to fix it, they are messy and this "just worked."

Given that `image` is already taken, I opted for `inputImage`.