### PR TITLE
Improve performance on large images

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@
 ### Release 0.8
 
  - added reset() method on ImageCropperComponent - fix for  #118   
- - added compressRatio as parameter in the cropper settings 
+ - added compressRatio as parameter in the cropper settings
 
 ### Release 0.7.6
 
@@ -24,7 +24,7 @@
 
 ### Release 0.7.1
  - Fixed #87 get unsacled crop of image
- 
+
 
 ### Release 0.7.0
  - update for AngularJS 2.0.1
@@ -69,7 +69,7 @@ Please change your system.config files to make use of the js files.
 # ng2-img-cropper
 
 This is an adapatation of Angular 1 image cropper from: https://github.com/AllanBishop/angular-img-cropper
-An image cropping tool for AngularJS. Features a rectangular crop area. The crop area's aspect ratio can be enforced during dragging. 
+An image cropping tool for AngularJS. Features a rectangular crop area. The crop area's aspect ratio can be enforced during dragging.
 The crop image can either be 1:1 or scaled to fit an area.
 
 ## Install from NPM
@@ -140,7 +140,7 @@ Checkout this [sample plunker](https://embed.plnkr.co/VFwGvAO6MhV06IDTLk5W/)
 * **croppedHeight**:*number* - Resulting image height
 * **touchRadius**:*number* - (default: 20) Touch devices radius
 * **minWithRelativeToResolution**:*boolean* - (default: true) By default the resulting image will be cropped from original image. If false, it will be cropped from canvas pixels
-* **noFileInput**:*boolean* - (default: false) - hides the file input element from cropper canvas. 
+* **noFileInput**:*boolean* - (default: false) - hides the file input element from cropper canvas.
 * **cropperDrawSettings**:*CropperDrawSettings* - rendering options
     * **strokeWidth**:*number* - box/ellipsis stroke width
     * **strokeColor**:*string* - box/ellipsis stroke color
@@ -152,7 +152,7 @@ Checkout this [sample plunker](https://embed.plnkr.co/VFwGvAO6MhV06IDTLk5W/)
 * **cropperClass**: string - set class on canvas element;
 * **croppingClass**: string - appends class to cropper when image is set (#142);
 * **resampleFn**: Function(canvas) - function used to resample the cropped image (#136); - see example #3 from runtime sample app
-
+* **cropOnResize**:*boolean* (default: true) - if true the cropper will create a new cropped Image object immediately when the crop area is resized
 
 ## Customizing Image cropper
 
@@ -174,7 +174,7 @@ Replacing component file input:
 
 data:any;
 
-@ViewChild('cropper', undefined) 
+@ViewChild('cropper', undefined)
 cropper:ImageCropperComponent;
 
 constructor() {
@@ -199,5 +199,3 @@ fileChangeListener($event) {
 
 
 ```
-
-

--- a/runtime/app.ts
+++ b/runtime/app.ts
@@ -153,7 +153,50 @@ this.cropPosition.w = 200;
 this.cropPosition.h = 250;
 </code>
 </pre>
-</tab>    
+</tab>
+
+<tab title="No Crop on Resize" [disabled]="false">
+    <div class="row">
+    <div class="col-md-9">
+        <h3>source</h3>
+        <img-cropper #cropper4 [image]="data4" [settings]="cropperSettings4"></img-cropper>
+        <br/>
+        <button class="btn btn-primary" (click)="getImage()">Crop Image</button>
+    </div>
+    <h3>result</h3>
+    <div class="col-md-3">
+        <span *ngIf="data4.image" >
+            <img [src]="data4.image" [width]="200">
+        </span>
+    </div>
+    </div>
+<h3>settings</h3>
+<pre>
+<code>
+this.cropperSettings4 = new CropperSettings();
+this.cropperSettings4.width = 200;
+this.cropperSettings4.height = 200;
+
+this.cropperSettings4.croppedWidth = 200;
+this.cropperSettings4.croppedHeight = 200;
+
+this.cropperSettings4.canvasWidth = 500;
+this.cropperSettings4.canvasHeight = 300;
+
+this.cropperSettings4.minWidth = 100;
+this.cropperSettings4.minHeight = 100;
+
+this.cropperSettings4.rounded = false;
+
+this.cropperSettings4.cropperDrawSettings.strokeColor = 'rgba(255,255,255,1)';
+this.cropperSettings4.cropperDrawSettings.strokeWidth = 2;
+
+this.cropperSettings4.keepAspect = true;
+this.cropperSettings4.preserveSize = true;
+this.cropperSettings4.cropOnResize = false;
+</code>
+</pre>
+</tab>
 </tabset>
     `
 })
@@ -176,6 +219,9 @@ export class AppComponent extends Type {
     @ViewChild('cropper3', undefined)
     public cropper3:ImageCropperComponent;
 
+    @ViewChild('cropper4', undefined)
+    public cropper4:ImageCropperComponent;
+
     public onChange:Function;
     public updateCropPosition:Function;
     public resetCroppers:Function;
@@ -185,6 +231,8 @@ export class AppComponent extends Type {
     public cropperSettings3:CropperSettings;
     public cropPosition:CropPosition;
 
+    //Cropper 4 data
+    public cropperSettings4:CropperSettings;
 
     constructor() {
         super();
@@ -293,6 +341,35 @@ export class AppComponent extends Type {
 
         this.data3 = {};
 
+        //Cropper settings 4
+        this.cropperSettings4 = new CropperSettings();
+        this.cropperSettings4.width = 200;
+        this.cropperSettings4.height = 200;
+
+        this.cropperSettings4.croppedWidth = 200;
+        this.cropperSettings4.croppedHeight = 200;
+
+        this.cropperSettings4.canvasWidth = 500;
+        this.cropperSettings4.canvasHeight = 300;
+
+        this.cropperSettings4.minWidth = 100;
+        this.cropperSettings4.minHeight = 100;
+
+        this.cropperSettings4.rounded = false;
+
+        this.cropperSettings4.cropperDrawSettings.strokeColor = 'rgba(255,255,255,1)';
+        this.cropperSettings4.cropperDrawSettings.strokeWidth = 2;
+
+        this.cropperSettings4.keepAspect = true;
+        this.cropperSettings4.preserveSize = true;
+        this.cropperSettings4.cropOnResize = false;
+
+        this.data4 = {};
+
+        this.getImage = () => {
+          this.data4.image = this.cropper4.cropper.getCroppedImage(true).src;
+        }
+
         this.onChange = ($event:any) => {
             var image:any = new Image();
             var file:File = $event.target.files[0];
@@ -313,6 +390,7 @@ export class AppComponent extends Type {
             this.cropper1.reset();
             this.cropper2.reset();
             this.cropper3.reset();
+            this.cropper4.reset();
         }
 
 

--- a/src/cropperSettings.ts
+++ b/src/cropperSettings.ts
@@ -17,6 +17,7 @@ export interface ICropperSettings {
     rounded: boolean;
     keepAspect: boolean;
     preserveSize: boolean;
+    cropOnResize: boolean;
     compressRatio: number;
 }
 
@@ -47,6 +48,7 @@ export class CropperSettings implements ICropperSettings {
     public resampleFn:Function;
 
     public allowedFilesRegex: RegExp = /\.(jpe?g|png|gif)$/i;
+    public cropOnResize: boolean = true;
     public preserveSize: boolean = false;
 
     public compressRatio:number = 1.0;

--- a/src/imageCropper.ts
+++ b/src/imageCropper.ts
@@ -676,7 +676,7 @@ export class ImageCropper extends ImageCropperModel {
 
         this.vertSquashRatio = ImageCropper.detectVerticalSquash(this.srcImage);
         this.draw(this.ctx);
-        this.croppedImage = this.getCroppedImage(this.cropWidth, this.cropHeight);
+        this.croppedImage = this.getCroppedImageHelper(false, this.cropWidth, this.cropHeight);
     }
 
     private getCropPositionFromMarkers():Point[] {
@@ -757,8 +757,15 @@ export class ImageCropper extends ImageCropperModel {
         return positions;
     }
 
+    public getCroppedImageHelper(preserveSize?:boolean, fillWidth?:number, fillHeight?:number):HTMLImageElement {
+        if (this.cropperSettings.cropOnResize) {
+            return this.getCroppedImage(preserveSize, fillWidth, fillHeight);
+        }
+        return this.croppedImage? this.croppedImage : document.createElement('img');
+    }
+
     // todo: Unused parameters?
-    public getCroppedImage(fillWidth?:number, fillHeight?:number):HTMLImageElement {
+    public getCroppedImage(preserveSize?:boolean, fillWidth?:number, fillHeight?:number):HTMLImageElement {
         let bounds:Bounds = this.getBounds();
         if (!this.srcImage) {
             return document.createElement('img');
@@ -787,7 +794,7 @@ export class ImageCropper extends ImageCropperModel {
             let ctx = <CanvasRenderingContext2D> this.cropCanvas.getContext('2d');
 
 
-            if (this.cropperSettings.preserveSize) {
+            if (this.cropperSettings.preserveSize || preserveSize) {
                 var width = Math.round(bounds.right/this.ratioW - bounds.left/this.ratioW);
                 var height = Math.round(bounds.bottom/this.ratioH - bounds.top/this.ratioH);
 

--- a/src/imageCropperComponent.ts
+++ b/src/imageCropperComponent.ts
@@ -79,7 +79,7 @@ export class ImageCropperComponent implements AfterViewInit, OnChanges {
             this.cropper.updateCropPosition(this.cropPosition.toBounds());
             if (this.cropper.isImageSet()) {
                 let bounds = this.cropper.getCropBounds();
-                this.image.image = this.cropper.getCroppedImage().src;
+                this.image.image = this.cropper.getCroppedImageHelper().src;
                 this.onCrop.emit(bounds);
             }
             this.updateCropBounds();
@@ -101,7 +101,7 @@ export class ImageCropperComponent implements AfterViewInit, OnChanges {
     public onTouchEnd(event:TouchEvent):void {
         this.cropper.onTouchEnd(event);
         if (this.cropper.isImageSet()) {
-            this.image.image = this.cropper.getCroppedImage().src;
+            this.image.image = this.cropper.getCroppedImageHelper().src;
             this.onCrop.emit(this.cropper.getCropBounds());
             this.updateCropBounds();
         }
@@ -114,7 +114,7 @@ export class ImageCropperComponent implements AfterViewInit, OnChanges {
     public onMouseUp(event:MouseEvent):void {
         if (this.cropper.isImageSet()) {
             this.cropper.onMouseUp(event);
-            this.image.image = this.cropper.getCroppedImage().src;
+            this.image.image = this.cropper.getCroppedImageHelper().src;
             this.onCrop.emit(this.cropper.getCropBounds());
             this.updateCropBounds();
         }
@@ -145,7 +145,7 @@ export class ImageCropperComponent implements AfterViewInit, OnChanges {
     public reset():void {
         this.cropper.reset();
         this.renderer.setElementAttribute(this.cropcanvas.nativeElement, 'class', this.settings.cropperClass);
-        this.image.image = this.cropper.getCroppedImage().src;
+        this.image.image = this.cropper.getCroppedImageHelper().src;
     }
 
     public setImage(image:HTMLImageElement, newBounds:any = null) {
@@ -177,7 +177,7 @@ export class ImageCropperComponent implements AfterViewInit, OnChanges {
                     }
                     self.image.original = img;
                     let bounds = self.cropper.getCropBounds();
-                    self.image.image = self.cropper.getCroppedImage().src;
+                    self.image.image = self.cropper.getCroppedImageHelper().src;
                     if (newBounds != null) {
                         bounds = newBounds;
                         self.cropper.setBounds(bounds);


### PR DESCRIPTION
Add cropOnResize setting to toggle whether image object is created each
time box is resized.
Add preserveSize parameter to getCroppedImage to allow users to manually
get full resolution image using ViewChild and cropper.getCroppedImage()