### PR TITLE
Remove resize event listener on destroy

### DIFF
--- a/src/imageCropperComponent.ts
+++ b/src/imageCropperComponent.ts
@@ -1,4 +1,4 @@
-import {Component, Input, Renderer, ViewChild, ElementRef, Output, EventEmitter, Type, AfterViewInit, OnChanges, SimpleChanges} from '@angular/core';
+import {Component, Input, Renderer, ViewChild, ElementRef, Output, EventEmitter, Type, AfterViewInit, OnChanges, OnDestroy, SimpleChanges} from '@angular/core';
 import {ImageCropper} from './imageCropper';
 import {CropperSettings} from './cropperSettings';
 import {Exif} from './exif';
@@ -22,7 +22,7 @@ import {CropPosition} from './model/cropPosition';
         </span>
       `
 })
-export class ImageCropperComponent implements AfterViewInit, OnChanges {
+export class ImageCropperComponent implements AfterViewInit, OnChanges, OnDestroy {
 
     @ViewChild('cropcanvas', undefined) cropcanvas:ElementRef;
 
@@ -40,6 +40,7 @@ export class ImageCropperComponent implements AfterViewInit, OnChanges {
     public intervalRef:number;
     public raf:number;
     public renderer:Renderer;
+    public windowListener: EventListenerObject;
 
     private isCropPositionUpdateNeeded:boolean;
 
@@ -60,11 +61,8 @@ export class ImageCropperComponent implements AfterViewInit, OnChanges {
             this.renderer.setElementAttribute(canvas, 'width', this.settings.canvasWidth.toString());
             this.renderer.setElementAttribute(canvas, 'height', this.settings.canvasHeight.toString());
         } else {
-            window.addEventListener('resize', () => {
-                this.settings.canvasWidth = canvas.offsetWidth;
-                this.settings.canvasHeight = canvas.offsetHeight;
-                this.cropper.resizeCanvas(canvas.offsetWidth, canvas.offsetHeight, true);
-            });
+            this.windowListener = this.resize.bind(this);
+            window.addEventListener('resize', this.windowListener);
         }
 
         if (!this.cropper) {
@@ -87,6 +85,12 @@ export class ImageCropperComponent implements AfterViewInit, OnChanges {
 
         if (changes.inputImage) {
           this.setImage(changes.inputImage.currentValue);
+        }
+    }
+
+    public ngOnDestroy() {
+        if (this.settings.dynamicSizing && this.windowListener) {
+            window.removeEventListener('resize', this.windowListener);
         }
     }
 
@@ -140,6 +144,13 @@ export class ImageCropperComponent implements AfterViewInit, OnChanges {
 
             fileReader.readAsDataURL(file);
         }
+    }
+
+    private resize() {
+        let canvas:HTMLCanvasElement = this.cropcanvas.nativeElement;
+        this.settings.canvasWidth = canvas.offsetWidth;
+        this.settings.canvasHeight = canvas.offsetHeight;
+        this.cropper.resizeCanvas(canvas.offsetWidth, canvas.offsetHeight, true);
     }
 
     public reset():void {


### PR DESCRIPTION
In the current setup, if you have `dynamicSizing` on, a resize listener gets added to `window`, but never removed (leaks).

This causes issues if, say, you have the image cropper in a modal, which is then closed. The resize listener keeps trying to update the canvas whenever the window is resized, but the canvas is gone, causing errors to be thrown.

It also means every time a new image cropper is spawned, another listener is added to the window.

This cleans up the window listener when the image cropper component is destroyed.