### PR TITLE
Responsive: set initial crop bounds

### DIFF
--- a/src/imageCropperComponent.ts
+++ b/src/imageCropperComponent.ts
@@ -175,6 +175,7 @@ export class ImageCropperComponent implements AfterViewInit, OnChanges {
                     if (newBounds != null) {
                         bounds = newBounds;
                         self.cropper.setBounds(bounds);
+                        this.cropper.updateCropPosition(bounds);
                     }
                     self.onCrop.emit(bounds);
                 });


### PR DESCRIPTION
If you have the image already loaded and calculated the drawing area (based on that image), the responsive-feature does not work correctly.
After calculating the bounds, they have not only to be emitted, but updated in the class itself.