### PR TITLE
minWidth/minHeight should calculated from cropperSettings

### DIFF
--- a/src/imageCropper.ts
+++ b/src/imageCropper.ts
@@ -645,8 +645,8 @@ export class ImageCropper extends ImageCropperModel {
                 this.fileType = this.getDataUriMimeType(img.src);
 
             if (this.cropperSettings.minWithRelativeToResolution) {
-                this.minWidth = (this.canvas.width * this.minWidth / this.srcImage.width);
-                this.minHeight = (this.canvas.height * this.minHeight / this.srcImage.height);
+                this.minWidth = (this.canvas.width * this.cropperSettings.minWidth / this.srcImage.width);
+                this.minHeight = (this.canvas.height * this.cropperSettings.minHeight / this.srcImage.height);
             }
 
             this.updateClampBounds();


### PR DESCRIPTION
because, if you call the setImage multiple times, they are using the previous values.