### PR TITLE
Add caret range to angular peerDependencies fixes #171

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,9 +31,9 @@
   ],
   "license": "MIT",
   "peerDependencies": {
-    "@angular/common": "4.0.0",
-    "@angular/compiler": "4.0.0",
-    "@angular/core": "4.0.0"
+    "@angular/common": "^4.0.0",
+    "@angular/compiler": "^4.0.0",
+    "@angular/core": "^4.0.0"
   },
   "devDependencies": {
     "@angular/common": "4.0.0",


### PR DESCRIPTION
Currently causing NPM warnings when using an Angular version that is greater than 4.0.0.